### PR TITLE
Load Nats URL from env variable if set

### DIFF
--- a/{{cookiecutter.module}}/cmd/{{cookiecutter.module}}/main.go
+++ b/{{cookiecutter.module}}/cmd/{{cookiecutter.module}}/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -76,9 +77,14 @@ func main() {
 	}
 
 	/* If set, environment variables override config file */
-	url, exists := os.LookupEnv("TAPIR_ANALYSE_NATS_URL")
-	if exists {
-		mainConf.Nats.Url = url
+	natsURL, exists := os.LookupEnv("TAPIR_ANALYSE_NATS_URL")
+	if exists && natsURL != "" {
+		parsedURL, err := url.Parse(natsURL)
+		if err != nil {
+			fmt.Printf("Invalid NATS URL format from environment variable '%s': %s, exiting...\n", natsURL, err)
+			os.Exit(-1)
+		}
+		mainConf.Nats.Url = parsedURL.String()
 	}
 
 	application, err := setup.BuildApp(mainConf)

--- a/{{cookiecutter.module}}/cmd/{{cookiecutter.module}}/main.go
+++ b/{{cookiecutter.module}}/cmd/{{cookiecutter.module}}/main.go
@@ -75,6 +75,12 @@ func main() {
 		mainConf.Quiet = true
 	}
 
+	/* If set, environment variables override config file */
+	url, exists := os.LookupEnv("TAPIR_ANALYSE_NATS_URL")
+	if exists {
+		mainConf.Nats.Url = url
+	}
+
 	application, err := setup.BuildApp(mainConf)
 	if err != nil {
 		fmt.Printf("Error building application: '%s', exiting...\n", err)


### PR DESCRIPTION
Checks if there exists an env var called "TAPIR_ANALYSE_NATS_URL" and if so overrides the value from the configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the NATS URL configuration using an environment variable (TAPIR_ANALYSE_NATS_URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->