### PR TITLE
added codeowners, tapir core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dnstapir/core


### PR DESCRIPTION
fix #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a CODEOWNERS file to automatically assign the `@dnstapir/core` team as reviewers for all changes in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->